### PR TITLE
fixes #9569 - do not install GB conf or dir

### DIFF
--- a/rubygem-foreman_gutterball.spec
+++ b/rubygem-foreman_gutterball.spec
@@ -31,7 +31,7 @@ Requires: %{?scl_prefix}rubygem-katello
 Requires: %{?scl_prefix}rubygems
 BuildRequires: %{?scl_prefix}rubygems
 BuildRequires: %{?scl_prefix}rubygems-devel
-BuildRequires: foreman-assets >= 1.7.0
+BuildRequires: foreman-plugin >= 1.8
 %if 0%{?rhel} > 6
 Requires: ruby(release) = 2.0.0
 BuildRequires: ruby(release) = 2.0.0
@@ -72,8 +72,6 @@ gem install --local --install-dir .%{gem_dir} --force %{SOURCE0} --no-rdoc --no-
 %{__install} --directory %{buildroot}%{foreman_bundlerd_dir}
 
 %foreman_bundlerd_file
-
-%{__install} --directory %{buildroot}%{foreman_dir}/plugins
 
 %clean
 %{__rm} --recursive --force %{buildroot} .%{gem_dir}


### PR DESCRIPTION
also updating spec to BuildRequire the correct package to pull in the
`%foreman_bundlerd_file` macro