### PR TITLE
fixes #9656 - output hour, minute, second to content-host-trend

### DIFF
--- a/app/services/foreman_gutterball/gutterball_service.rb
+++ b/app/services/foreman_gutterball/gutterball_service.rb
@@ -67,7 +67,7 @@ module ForemanGutterball
 
     def format_consumer_trend_response(response)
       response.map do |member|
-        { :date => iso8601_to_yyyy_mm_dd(member['status']['date']),
+        { :date => iso8601_to_yyyy_mm_dd_hms(member['status']['date']),
           :status => member['status']['status'] }
       end
     end
@@ -82,6 +82,10 @@ module ForemanGutterball
 
     def iso8601_to_yyyy_mm_dd(datetime)
       DateTime.iso8601(datetime).strftime('%Y-%m-%d')
+    end
+
+    def iso8601_to_yyyy_mm_dd_hms(datetime)
+      DateTime.iso8601(datetime).strftime('%Y-%m-%d %H:%M:%S')
     end
   end
 end


### PR DESCRIPTION
```
$ hammer content-report content-host-trend --organization-label megacorp --content-host-id aceb31b3-280e-4a43-b744-b8d9fc056a51
Task 38e99cae-6dd1-4dfd-8ac6-2ac35586d97f: success
Date,Status
2015-03-05 13:07:13,valid
2015-03-05 13:26:02,invalid
```